### PR TITLE
Update README.md

### DIFF
--- a/pks/nat/README.md
+++ b/pks/nat/README.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-This topology uses NAT for all Management and Kubernetes cluster(s) logical networking. The PKS Mgmt components use DNAT rules created on the T0 to access the Private PKS Mgmt network. Kubernetes Clusters are accessed through the NSX Loadbalancer that is automatically instantiated at the time of cluster creation.
+This topology uses NAT for all Management and Kubernetes cluster(s) logical networking. Access to the PKS management components utilize DNAT rules created on the T0 to access the "PKS MGMT" network. Kubernetes clusters are accessed through the NSX Loadbalancer that is automatically instantiated at the time of cluster creation.
 
 In this topology the Kubernetes Node networks are Private Networks that are allocated from the **IP Block** for the **K8s Cluster Networks**. This configuration is done by putting a checkmark in the **NAT mode** box in the PKS tile in Opsman.
 
 <img src="../images/nat-diagram.png">
 
-### It expects this:
+### Prerequisites prior to Terraform Provisioning:
 * NSX Manager
 * NSX Controllers
 * NSX Edge Nodes
@@ -20,7 +20,7 @@ In this topology the Kubernetes Node networks are Private Networks that are allo
 ### Created by Terraform:
 * 1 T0 Router
     * T0 Default Route
-* NAT Rules for PKS MGMT Private Network
+* DNAT Rules for PKS MGMT Private Network
     * Opsman
     * BOSH
     * PKS Controller


### PR DESCRIPTION
Changed some wording...a question for you...
Is the name of the IP Block still IP Block for Nodes and Pods?  You reference and bold an IP Block for "K8s Cluster Networks".  It may be preferable to label it the same as you would see in the PKS Tile in OpsMan, but I was not sure if this was a Terraform nomenclature.

Also, I would change the image to remove the red-misspelling squiggly lines under Opsman etc.

There is also not mention of the SNAT rules to allow for BOSH to talk to vCenter and ESXi.  Should that be mentioned in the NAT configuration section?